### PR TITLE
Migrate backend to .NET 10

### DIFF
--- a/backend/.github/workflows/dotnet.yml
+++ b/backend/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Restore dependencies
       run : cd src/LXP.API && dotnet restore
     - name: Build

--- a/backend/global.json
+++ b/backend/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}

--- a/backend/src/LXP.API/LXP.Api.csproj
+++ b/backend/src/LXP.API/LXP.Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/backend/src/LXP.Api.Tests/LXP.Api.Tests.csproj
+++ b/backend/src/LXP.Api.Tests/LXP.Api.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/backend/src/LXP.Common.Tests/LXP.Common.Tests.csproj
+++ b/backend/src/LXP.Common.Tests/LXP.Common.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/backend/src/LXP.Common/LXP.Common.csproj
+++ b/backend/src/LXP.Common/LXP.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/backend/src/LXP.Core.Tests/LXP.Core.Tests.csproj
+++ b/backend/src/LXP.Core.Tests/LXP.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/backend/src/LXP.Core/LXP.Core.csproj
+++ b/backend/src/LXP.Core/LXP.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/backend/src/LXP.Data.Tests/LXP.Data.Tests.csproj
+++ b/backend/src/LXP.Data.Tests/LXP.Data.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/backend/src/LXP.Data/LXP.Data.csproj
+++ b/backend/src/LXP.Data/LXP.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
### Motivation
- Move the backend projects to the latest major runtime to take advantage of new platform features and align CI with the updated SDK.
- Ensure continuous integration installs and uses the .NET 10 SDK instead of .NET 8.
- Pin the SDK version for consistent local and CI builds via a `global.json` file.

### Description
- Updated `TargetFramework` in all backend `.csproj` files from `net8.0` to `net10.0` for API, libraries, and test projects.
- Updated the GitHub Actions workflow `backend/.github/workflows/dotnet.yml` to use `dotnet-version: 10.0.x` for CI builds and tests.
- Added `backend/global.json` to pin the SDK to `10.0.100` and set `rollForward` to `latestFeature`.
- Verified project and workflow files to remove references to `net8.0` and `dotnet-version: 8.0.x`.

### Testing
- Ran a repository search with `rg` for `net8.0` and `dotnet-version: 8.0.x` which returned no remaining matches, indicating updates were applied.
- Attempted `dotnet --version` to validate the installed SDK but it failed in this environment because the `dotnet` CLI is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3d2301210832bbda6abef6c724d99)