### PR TITLE
Refactor LearnerGetCourse middleware, remove debug logs, and add unit tests

### DIFF
--- a/frontend/src/__test__/Learner.test.js
+++ b/frontend/src/__test__/Learner.test.js
@@ -1,0 +1,67 @@
+import axios from 'axios';
+import LearnerGetCourse from '../middleware/LearnerMiddleware/LearnerGetCourse';
+import {
+  GET_COURSES_FAILURE,
+  GET_COURSES_REQUEST,
+  GET_COURSES_SUCCESS,
+} from '../actions/LearnerAction/LearnerGetCourseAction';
+
+jest.mock('axios');
+
+describe('LearnerGetCourse middleware', () => {
+  const next = jest.fn();
+  let dispatch;
+  let invoke;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    dispatch = jest.fn();
+    invoke = LearnerGetCourse({ dispatch })(next);
+  });
+
+  it('dispatches success when the API returns course data', async () => {
+    const action = { type: GET_COURSES_REQUEST, payload: 7 };
+    axios.get.mockResolvedValue({
+      status: 200,
+      data: {
+        data: {
+          result: {
+            result: [{ courseId: 1, title: 'React Basics' }],
+          },
+        },
+      },
+    });
+
+    await invoke(action);
+
+    expect(next).toHaveBeenCalledWith(action);
+    expect(axios.get).toHaveBeenCalledWith(
+      'http://localhost:5199/lxp/view/Getallcoursebylearnerid/7'
+    );
+    expect(dispatch).toHaveBeenCalledWith({
+      type: GET_COURSES_SUCCESS,
+      payload: [{ courseId: 1, title: 'React Basics' }],
+    });
+  });
+
+  it('dispatches failure when learner id is missing', async () => {
+    await invoke({ type: GET_COURSES_REQUEST, payload: '' });
+
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith({
+      type: GET_COURSES_FAILURE,
+      payload: 'Learner id is required to fetch courses',
+    });
+  });
+
+  it('dispatches failure when API call throws an error', async () => {
+    axios.get.mockRejectedValue(new Error('Network down'));
+
+    await invoke({ type: GET_COURSES_REQUEST, payload: 23 });
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: GET_COURSES_FAILURE,
+      payload: 'Network down',
+    });
+  });
+});

--- a/frontend/src/middleware/LearnerMiddleware/LearnerGetCourse.js
+++ b/frontend/src/middleware/LearnerMiddleware/LearnerGetCourse.js
@@ -1,31 +1,47 @@
 import axios from 'axios';
-import { GET_COURSES_REQUEST, getCoursesFailure, getCoursesSuccess } from '../../actions/LearnerAction/LearnerGetCourseAction';
- 
- 
+import {
+  GET_COURSES_REQUEST,
+  getCoursesFailure,
+  getCoursesSuccess,
+} from '../../actions/LearnerAction/LearnerGetCourseAction';
+
+const buildCoursesEndpoint = (learnerId) =>
+  `http://localhost:5199/lxp/view/Getallcoursebylearnerid/${learnerId}`;
+
+const extractCourses = (responseData) => {
+  const courses = responseData?.data?.result?.result;
+  return Array.isArray(courses) ? courses : null;
+};
+
 const LearnerGetCourse = ({ dispatch }) => (next) => async (action) => {
   next(action);
-  console.log("coursegetapi", action)
-  const API_URL = `http://localhost:5199/lxp/view/Getallcoursebylearnerid/${action.payload}`;
- 
-  if (action.type === GET_COURSES_REQUEST) {
-    try {
-      console.log("learnerapicomponent:", action);
-      const response = await axios.get(`${API_URL}`);
-      console.log(`${API_URL}${action.payload}`);
-      console.log('API  mycourse Response:', response.data); // Log the response data
- 
-      if (response.status === 200 && response.data && response.data.data && response.data.data.result) {
-        const courses = response.data.data.result.result; // Extract the courses array
-        console.log(courses);
-        dispatch(getCoursesSuccess(courses));
-      } else {
-        console.error('No valid data received from API');
-        dispatch(getCoursesFailure('No valid data received from API'));
-      }
-    } catch (error) {
-      console.error('API Error:', error.message);
-      dispatch(getCoursesFailure(error.message));
+
+  if (action.type !== GET_COURSES_REQUEST) {
+    return;
+  }
+
+  const learnerId = action.payload;
+  if (!learnerId) {
+    dispatch(getCoursesFailure('Learner id is required to fetch courses'));
+    return;
+  }
+
+  try {
+    const apiUrl = buildCoursesEndpoint(learnerId);
+    const response = await axios.get(apiUrl);
+    const courses = extractCourses(response.data);
+
+    if (response.status === 200 && courses) {
+      dispatch(getCoursesSuccess(courses));
+      return;
     }
+
+    dispatch(getCoursesFailure('No valid data received from API'));
+  } catch (error) {
+    const errorMessage = error?.message || 'Unable to fetch courses';
+    dispatch(getCoursesFailure(errorMessage));
   }
 };
+
+export { buildCoursesEndpoint, extractCourses };
 export default LearnerGetCourse;


### PR DESCRIPTION
### Motivation
- Improve reliability and readability of the learner course fetch path by removing noisy debug logging and adding input validation. 
- Make the middleware easier to test and follow single-responsibility principles by extracting endpoint construction and response parsing.

### Description
- Refactored `frontend/src/middleware/LearnerMiddleware/LearnerGetCourse.js` to add an early action-type guard and validate the `learnerId` payload before making requests, and to standardize error handling.
- Extracted helper functions `buildCoursesEndpoint` and `extractCourses` to encapsulate URL construction and response parsing.
- Removed `console.log`/`console.error` debug output from the middleware to keep production logs clean.
- Added unit tests at `frontend/src/__test__/Learner.test.js` that cover the success path, missing `learnerId` validation, and API error handling.

### Testing
- Added Jest unit test `frontend/src/__test__/Learner.test.js` and executed `npm install` in the `frontend` workspace to prepare the test environment (node modules were installed). 
- Attempted to run `npm test -- --watch=false --runTestsByPath src/__test__/Learner.test.js`, but test execution failed because `react-scripts` could not be executed in this environment due to registry access restrictions (`403 Forbidden` when attempting to fetch `react-scripts`), so the added tests were not runnable here.
- No other automated test suites were run due to dependency resolution limits in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3d9156c94832bb8a3a06bc1a2b36d)