### PR TITLE
Refactor frontend API access into feature modules with shared async hook

### DIFF
--- a/frontend/src/components/Admin/CourseWiseEnrolledChart.jsx
+++ b/frontend/src/components/Admin/CourseWiseEnrolledChart.jsx
@@ -17,8 +17,10 @@ import {
   Legend,
 } from "chart.js";
 import { Pie, Doughnut, Line } from "react-chartjs-2";
-import axios from "axios";
 import { Paper, Button, Typography } from "@mui/material";
+import { getCourseWiseEnrollmentCount } from "../../features/admin/api/dashboardApi";
+import { mapCourseEnrollmentsToChartData } from "../../features/admin/selectors/dashboardSelectors";
+import useAsyncRequest from "../../hooks/useAsyncRequest";
 
 const Item = styled(Paper)(({ theme }) => ({
   backgroundColor: theme.palette.mode === "dark" ? "#1A2027" : "#fff",
@@ -46,60 +48,39 @@ ChartJS.register(
 );
 
 const CourseWiseEnrolledChart = () => {
-  const [chartData, setChartData] = useState(null);
   const [chartType, setChartType] = useState("pie");
+  const {
+    data: chartData,
+    error,
+    isLoading,
+    run: loadCourseEnrollmentData,
+  } = useAsyncRequest(getCourseWiseEnrollmentCount, []);
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await axios.get(
-          "http://localhost:5199/lxp/admin/GetCourseWiseEnrollmentsCount"
-        );
-        const data = response.data.data;
-        setChartData({
-          labels: data.map((row) => row.courseName),
-          datasets: [
-            {
-              label: "Enrollments",
-              data: data.map((row) => row.count),
-              backgroundColor: [
-                "#FF6384",
-                "#36A2EB",
-                "#FFCE56",
-                "#4BC0C0",
-                "#9966FF",
-                "#FF9F40",
-                "#003f5c",
-                "#2f4b7c",
-                "#665191",
-                "#a05195",
-                "#d45087",
-                "#f95d6a",
-                "#ff7c43",
-                "#ffa600",
-              ],
-              borderColor:
-                chartType === "line" ? "rgba(75,192,192,1)" : undefined,
-              borderWidth: chartType === "line" ? 2 : undefined,
-            },
-          ],
-        });
+        await loadCourseEnrollmentData();
       } catch (error) {
         console.error("Error fetching course enrollments", error);
       }
     };
 
     fetchData();
-  }, [chartType]);
+  }, [loadCourseEnrollmentData]);
+
+  const normalizedChartData =
+    chartData.length > 0
+      ? mapCourseEnrollmentsToChartData(chartData, chartType)
+      : null;
 
   const renderChart = () => {
     switch (chartType) {
       case "doughnut":
-        return <Doughnut data={chartData} />;
+        return <Doughnut data={normalizedChartData} />;
       case "line":
-        return <Line data={chartData} />;
+        return <Line data={normalizedChartData} />;
       default:
-        return <Pie data={chartData} />;
+        return <Pie data={normalizedChartData} />;
     }
   };
 
@@ -160,7 +141,9 @@ const CourseWiseEnrolledChart = () => {
                   </Button>
                 </div>
                 <div style={{ width: "100%", maxWidth: "400px" }}>
-                  {chartData ? renderChart() : <p>Loading...</p>}
+                  {isLoading && <p>Loading...</p>}
+                  {!isLoading && error && <p>Unable to load chart data.</p>}
+                  {!isLoading && !error && normalizedChartData && renderChart()}
                 </div>
               </div>
             </CardContent>

--- a/frontend/src/components/Admin/LearnerCount.jsx
+++ b/frontend/src/components/Admin/LearnerCount.jsx
@@ -1,27 +1,24 @@
-import React, { useEffect, useState } from 'react'
-import axios from 'axios';
+import React, { useEffect } from 'react'
 import { FaUserGraduate } from 'react-icons/fa';
+import { getTotalLearners } from '../../features/admin/api/dashboardApi';
+import useAsyncRequest from '../../hooks/useAsyncRequest';
 
 function LearnersCount() {
-    const [count, setCount] = useState(0);
-    const fetchData = async () => {
-        try {
-            const response = await axios.get(' http://localhost:5199/api/Dashboard/GetTotalLearners');
-            // console.log(response.data.data);
-            setCount(response.data.data);
-        } catch (error) {
-            console.error('Error fetching new learner count:', error);
-        }
-    };
+    const { data: count, error, isLoading, run: fetchData } = useAsyncRequest(getTotalLearners, 0);
 
     useEffect(() => {
-        fetchData();
-    }, []);
+        fetchData().catch((requestError) => {
+            console.error('Error fetching new learner count:', requestError);
+        });
+    }, [fetchData]);
+
     return (
         <div>
             <FaUserGraduate size={30} />
             <h5 className="card-title">Number of Learners</h5>
-            <p className="card-text">Count: <span id="learnerCount">{count}</span></p>
+            {isLoading && <p className="card-text">Loading...</p>}
+            {!isLoading && error && <p className="card-text">Unable to load learner count.</p>}
+            {!isLoading && !error && <p className="card-text">Count: <span id="learnerCount">{count}</span></p>}
         </div>
     )
 }

--- a/frontend/src/components/LearnerComponent/LearnerAudioViewer.js
+++ b/frontend/src/components/LearnerComponent/LearnerAudioViewer.js
@@ -20,6 +20,7 @@ import PauseIcon from "@mui/icons-material/Pause";
 import FullscreenIcon from "@mui/icons-material/Fullscreen";
 import FullscreenExitIcon from "@mui/icons-material/FullscreenExit";
 import { watchTimeRequest } from "../../actions/LearnerAction/WatchTimeAction";
+import { getLearnerMaterialWatchTime } from "../../features/learner/api/progressApi";
 //import { useDispatch, useSelector } from "react-redux";
  
 const Audio = styled.video`
@@ -201,20 +202,11 @@ const LearnerAudioViewer = ({ material, materialId ,materialName }) => {
   const fetchWatchTime = async () => {
     try {
       const learnerId = sessionStorage.getItem("UserSessionID");
-    
-     
-      const response = await fetch(`http://localhost:5199/lxp/course/learner/learnerprogress/watchtime?LearnerId=${learnerId}&MaterialId=${materialId}`);
-      const data = await response.json();
-    
-      if (data.data.watchTime) {
-        const parts = data.data.watchTime.split(':').map(Number);
-        const watchTimeInSeconds = parts[0] * 3600 + parts[1] * 60 + parts[2];
-        return watchTimeInSeconds;
-      }
+      return await getLearnerMaterialWatchTime({ learnerId, materialId });
     } catch (error) {
       console.error("Failed to fetch watch time:", error);
+      return 0;
     }
-     return 0;
   };
  
   useEffect(() => {

--- a/frontend/src/components/LearnerComponent/LearnerVideoViewer.js
+++ b/frontend/src/components/LearnerComponent/LearnerVideoViewer.js
@@ -20,6 +20,7 @@ import PauseIcon from "@mui/icons-material/Pause";
 import FullscreenIcon from "@mui/icons-material/Fullscreen";
 import FullscreenExitIcon from "@mui/icons-material/FullscreenExit";
 import { watchTimeRequest } from "../../actions/LearnerAction/WatchTimeAction";
+import { getLearnerMaterialWatchTime } from "../../features/learner/api/progressApi";
 //import watchTimeRequest from '../../actions/LearnerAction/WatchTimeAction';
 // import { updateWatchTimeRequest } from "../../actions/LearnerAction/UpdateWatchTimeAction";
 //import updateWatchTimeRequest from '../../actions/LearnerAction/UpdateWatchTimeAction';
@@ -175,20 +176,11 @@ const LearnerVideoViewer = ({ material,materialId ,materialName}) => {
   const fetchWatchTime = async () => {
     try {
       const learnerId = sessionStorage.getItem("UserSessionID");
-     
-     
-      const response = await fetch(`http://localhost:5199/lxp/course/learner/learnerprogress/watchtime?LearnerId=${learnerId}&MaterialId=${materialId}`);
-      const data = await response.json();
-     
-      if (data.data.watchTime) {
-        const parts = data.data.watchTime.split(':').map(Number);
-        const watchTimeInSeconds = parts[0] * 3600 + parts[1] * 60 + parts[2];
-        return watchTimeInSeconds;
-      }
+      return await getLearnerMaterialWatchTime({ learnerId, materialId });
     } catch (error) {
       console.error("Failed to fetch watch time:", error);
+      return 0;
     }
-     return 0;
   };
  
   useEffect(() => {

--- a/frontend/src/config/apiClient.js
+++ b/frontend/src/config/apiClient.js
@@ -1,0 +1,14 @@
+import axios from "axios";
+
+const API_BASE_URL =
+  process.env.REACT_APP_API_BASE_URL || "http://localhost:5199";
+
+const apiClient = axios.create({
+  baseURL: API_BASE_URL,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+export { API_BASE_URL };
+export default apiClient;

--- a/frontend/src/constants/apiEndpoints.js
+++ b/frontend/src/constants/apiEndpoints.js
@@ -1,0 +1,9 @@
+export const API_ENDPOINTS = {
+  admin: {
+    courseWiseEnrollmentCount: "/lxp/admin/GetCourseWiseEnrollmentsCount",
+    totalLearners: "/api/Dashboard/GetTotalLearners",
+  },
+  learner: {
+    watchTime: "/lxp/course/learner/learnerprogress/watchtime",
+  },
+};

--- a/frontend/src/features/admin/api/dashboardApi.js
+++ b/frontend/src/features/admin/api/dashboardApi.js
@@ -1,0 +1,12 @@
+import apiClient from "../../../config/apiClient";
+import { API_ENDPOINTS } from "../../../constants/apiEndpoints";
+
+export const getCourseWiseEnrollmentCount = async () => {
+  const response = await apiClient.get(API_ENDPOINTS.admin.courseWiseEnrollmentCount);
+  return response.data?.data || [];
+};
+
+export const getTotalLearners = async () => {
+  const response = await apiClient.get(API_ENDPOINTS.admin.totalLearners);
+  return response.data?.data || 0;
+};

--- a/frontend/src/features/admin/selectors/dashboardSelectors.js
+++ b/frontend/src/features/admin/selectors/dashboardSelectors.js
@@ -1,0 +1,29 @@
+const DEFAULT_CHART_COLORS = [
+  "#FF6384",
+  "#36A2EB",
+  "#FFCE56",
+  "#4BC0C0",
+  "#9966FF",
+  "#FF9F40",
+  "#003f5c",
+  "#2f4b7c",
+  "#665191",
+  "#a05195",
+  "#d45087",
+  "#f95d6a",
+  "#ff7c43",
+  "#ffa600",
+];
+
+export const mapCourseEnrollmentsToChartData = (enrollments, chartType) => ({
+  labels: enrollments.map((row) => row.courseName),
+  datasets: [
+    {
+      label: "Enrollments",
+      data: enrollments.map((row) => row.count),
+      backgroundColor: DEFAULT_CHART_COLORS,
+      borderColor: chartType === "line" ? "rgba(75,192,192,1)" : undefined,
+      borderWidth: chartType === "line" ? 2 : undefined,
+    },
+  ],
+});

--- a/frontend/src/features/learner/api/progressApi.js
+++ b/frontend/src/features/learner/api/progressApi.js
@@ -1,0 +1,19 @@
+import apiClient from "../../../config/apiClient";
+import { API_ENDPOINTS } from "../../../constants/apiEndpoints";
+import { watchTimeToSeconds } from "../helpers/progressHelpers";
+
+export const getLearnerMaterialWatchTime = async ({ learnerId, materialId }) => {
+  if (!learnerId || !materialId) {
+    return 0;
+  }
+
+  const response = await apiClient.get(API_ENDPOINTS.learner.watchTime, {
+    params: {
+      LearnerId: learnerId,
+      MaterialId: materialId,
+    },
+  });
+
+  const watchTime = response.data?.data?.watchTime;
+  return watchTimeToSeconds(watchTime);
+};

--- a/frontend/src/features/learner/helpers/progressHelpers.js
+++ b/frontend/src/features/learner/helpers/progressHelpers.js
@@ -1,0 +1,19 @@
+export const watchTimeToSeconds = (watchTime) => {
+  if (!watchTime || typeof watchTime !== "string") {
+    return 0;
+  }
+
+  const [hours = 0, minutes = 0, seconds = 0] = watchTime
+    .split(":")
+    .map((value) => Number(value));
+
+  if (
+    Number.isNaN(hours) ||
+    Number.isNaN(minutes) ||
+    Number.isNaN(seconds)
+  ) {
+    return 0;
+  }
+
+  return hours * 3600 + minutes * 60 + seconds;
+};

--- a/frontend/src/hooks/useAsyncRequest.js
+++ b/frontend/src/hooks/useAsyncRequest.js
@@ -1,0 +1,35 @@
+import { useCallback, useState } from "react";
+
+const useAsyncRequest = (asyncFn, initialData = null) => {
+  const [data, setData] = useState(initialData);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const run = useCallback(
+    async (...args) => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const result = await asyncFn(...args);
+        setData(result);
+        return result;
+      } catch (requestError) {
+        setError(requestError);
+        throw requestError;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [asyncFn]
+  );
+
+  return {
+    data,
+    error,
+    isLoading,
+    run,
+    setData,
+  };
+};
+
+export default useAsyncRequest;


### PR DESCRIPTION
### Motivation
- Centralize HTTP client and remove hard-coded endpoints from UI components to make API host/configuration configurable and consistent.
- Move network logic and data transformations out of components into feature APIs and selectors to keep components focused on rendering.
- Standardize async loading/error handling so components follow a shared pattern for requests and state.

### Description
- Added a shared Axios client with configurable base URL (`frontend/src/config/apiClient.js`) and a single `API_ENDPOINTS` map (`frontend/src/constants/apiEndpoints.js`).
- Introduced feature-scoped API modules: `features/admin/api/dashboardApi.js` and `features/learner/api/progressApi.js` to encapsulate requests and parameter handling.
- Moved business/transformation helpers into `features/admin/selectors/dashboardSelectors.js` and `features/learner/helpers/progressHelpers.js` to normalize chart payloads and convert watch-time strings.
- Added a reusable `useAsyncRequest` hook (`frontend/src/hooks/useAsyncRequest.js`) and updated components (`CourseWiseEnrolledChart`, `LearnerCount`, `LearnerVideoViewer`, `LearnerAudioViewer`) to use the feature APIs and hook instead of direct `axios`/`fetch` calls.

### Testing
- Attempted a production build with `npm --prefix frontend run build`, which failed in this environment because the build tooling dependency `react-scripts` is not available.
- Performed automated smoke checks using repository search to confirm updated components import and call the new feature APIs and helpers, which verified the intended replacements succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3daa03b1c832ba958078f7c919b58)